### PR TITLE
ci: enforce coverage gate in test workflow step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Install golangci-lint v2
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.2
 
-      - name: Test
-        run: make test
+      - name: Test with coverage gate (>=80%)
+        run: make cover-check COVER_MIN=80
 
       - name: Lint
         run: make lint


### PR DESCRIPTION
## 1) Problem / Context

- CI only ran `make test`, so minimum coverage enforcement was not guaranteed in the pipeline.
- We need CI to fail when coverage drops below the configured threshold.
- Linked issue/ticket: none

## 2) What Changed

- Updated `.github/workflows/ci.yml` test step name to explicitly indicate coverage gating.
- Replaced `make test` with `make cover-check COVER_MIN=80` in CI.
- Kept existing lint step unchanged.

## 3) Why This Approach

- Reuses existing Makefile target (`cover-check`) instead of introducing one-off workflow logic.
- Keeps coverage threshold explicit and reviewable in workflow config.
- Tradeoff: CI runtime may increase slightly due coverage instrumentation.

## 4) Risk and Rollback Plan

- Main risks: CI failures may increase if current or future tests drop below 80% coverage.
- Rollback strategy: revert this commit to restore `make test` behavior.
- Monitoring/alerts after merge: monitor GitHub Actions CI failures on `main` for coverage gate breakages.

## 5) Test Evidence

| Command | Result | Notes |
| --- | --- | --- |
| `make test` | PASS | all Go packages tested successfully |
| `make lint` | PASS | `golangci-lint` reported 0 issues |
| `git diff --name-status origin/main...HEAD` | PASS | change scope is one workflow file |

## 6) Security Notes

- Secret scan result: PASS (no sensitive filename or content patterns in diff).
- `gosec` result: FAIL (tool panics/SSA errors on current toolchain; also reports pre-existing findings outside changed file).
- `govulncheck` result: FAIL (reports existing Go stdlib vulns on `go1.25.4`, not introduced by this workflow-only change).
- Residual risk: repository-level security debt remains unresolved; this PR does not modify vulnerable runtime code paths.

## 7) Breaking Changes / Migration Notes

- Breaking change: no
- Migration steps: none
- Compatibility statement: compatible; runtime behavior unchanged, CI policy tightened.

## 8) Reviewer Checklist

- [ ] Code paths and edge cases make sense
- [ ] Tests and lint evidence are sufficient
- [ ] Security notes are acceptable
- [ ] Rollback strategy is practical
- [ ] Docs/changelog update is sufficient
