### PR TITLE
docs(readme): add TOC and refresh bilingual guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,29 @@ Language:
 - English (primary): `README.md`
 - Chinese: [README.zh-CN.md](README.zh-CN.md)
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Quick Start](#quick-start)
+- [Project Structure](#project-structure)
+- [Architecture and Data Flow](#architecture-and-data-flow)
+- [Common Commands](#common-commands)
+- [Configuration and Environment](#configuration-and-environment)
+- [Web API Example](#web-api-example)
+- [Testing and Quality](#testing-and-quality)
+- [Troubleshooting](#troubleshooting)
+- [Docker](#docker)
+- [Documentation Maintenance](#documentation-maintenance)
+- [Governance Files](#governance-files)
+
+<a id="overview"></a>
 ## Overview
 
 - Project type: `CLI tool + backend web service` (dual entrypoints).
 - Go version: `go 1.25.7` (from `go.mod`).
 - Module path: `github.com/johnqtcg/issue2md`.
 
+<a id="quick-start"></a>
 ## Quick Start
 
 ### Prerequisites
@@ -28,25 +45,20 @@ Language:
 
 ### Command Verifiability
 
-`Verified` below means executed in this agent session on `2026-03-04`.
-
-Verified in this session:
+Before running quality/build commands locally, install required tools and run:
 
 ```bash
 make help
-make fmt
-make test
-make lint
-make cover-check COVER_MIN=80
+make ci COVER_MIN=80
 make build-cli
 make web
 make swagger-check
 ./bin/issue2md --stdout https://github.com/github/spec-kit/issues/75
 ```
 
-Local note:
-- `make docker-build` failed locally in this session because Docker daemon was unreachable (`Cannot connect to the Docker daemon`).
-- Docker build validation is enforced in GitHub Actions on Linux runner (`docker-build` job).
+Verification policy:
+- Run commands in your own environment and treat output as the source of truth.
+- CI (`.github/workflows/ci.yml`) enforces the required gates on Linux runners.
 
 ### Build Locally
 
@@ -91,6 +103,7 @@ ISSUE2MD_WEB_ADDR=127.0.0.1:18080 ./bin/issue2mdweb
 ISSUE2MD_WEB_WRITE_TIMEOUT=90s ./bin/issue2mdweb
 ```
 
+<a id="project-structure"></a>
 ## Project Structure
 
 ```text
@@ -114,6 +127,7 @@ ISSUE2MD_WEB_WRITE_TIMEOUT=90s ./bin/issue2mdweb
 └── Dockerfile
 ```
 
+<a id="architecture-and-data-flow"></a>
 ## Architecture and Data Flow
 
 CLI path:
@@ -128,25 +142,26 @@ Web path:
 cmd/issue2mdweb -> internal/webapp -> internal/parser -> internal/github -> internal/converter -> HTTP response
 ```
 
+<a id="common-commands"></a>
 ## Common Commands
 
 Command source of truth: root `Makefile`.
 
 | Command | Purpose | Status |
 |---|---|---|
-| `make help` | List make targets | Verified (local session) |
-| `make fmt` | Format Go code with `gofmt` + `goimports-reviser` | Defined in Makefile + CI |
-| `make test` | Run all tests | Verified (local session) |
-| `make lint` | Run `golangci-lint` | Verified (local session) |
-| `make cover-check COVER_MIN=80` | Coverage gate | Verified (local session) |
-| `make build-cli` | Build CLI binary | Verified (local session) |
-| `make web` | Build Web binary | Verified (local session) |
-| `make swagger-check` | Regenerate and verify OpenAPI artifacts | Verified (local session) |
-| `./bin/issue2md --stdout <github-url>` | Real GitHub conversion | Verified (local session; requires `GITHUB_TOKEN`) |
-| `make test-api-integration` | API integration tests | Defined in Makefile + CI |
-| `make test-e2e-web` | Web E2E tests | Defined in Makefile + CI |
-| `make docker-build` | Build Docker image | Defined in Makefile + CI (Linux runner) |
+| `make help` | List make targets | Makefile |
+| `make fmt` | Format Go code with `gofmt` + `goimports-reviser` | Makefile + CI gate |
+| `make ci COVER_MIN=80` | Required CI-equivalent local gate (`fmt-check` + coverage + lint + build) | Makefile + CI |
+| `make test` | Run all tests | Makefile |
+| `make build-cli` | Build CLI binary | Makefile |
+| `make web` | Build Web binary | Makefile |
+| `make swagger-check` | Regenerate and verify OpenAPI artifacts | Makefile |
+| `./bin/issue2md --stdout <github-url>` | Real GitHub conversion | Requires `GITHUB_TOKEN` |
+| `make ci-api-integration` | API integration gate equivalent | Makefile + CI |
+| `make ci-e2e-web` | Web E2E gate equivalent | Makefile + CI (`push`/`schedule`) |
+| `make docker-build` | Build Docker image | Makefile + CI (Linux runner) |
 
+<a id="configuration-and-environment"></a>
 ## Configuration and Environment
 
 ### Runtime Environment Variables
@@ -179,6 +194,7 @@ Default output filename pattern (`internal/cli/output.go`):
 <owner>-<repo>-<issue|pr|discussion>-<number>.md
 ```
 
+<a id="web-api-example"></a>
 ## Web API Example
 
 Routes:
@@ -197,22 +213,60 @@ curl -sS -X POST http://127.0.0.1:8080/convert \
   --data-urlencode 'url=https://github.com/<owner>/<repo>/issues/1'
 ```
 
+<a id="testing-and-quality"></a>
 ## Testing and Quality
 
-Local quality gates:
-- `make fmt`
-- `make test`
-- `make lint`
-- `make cover-check COVER_MIN=80` (session result: `81.5%`)
+Local required gate:
+- `make ci COVER_MIN=80`
+
+Additional local checks:
+- `make ci-api-integration`
+- `make ci-e2e-web` (opt-in, same as CI e2e job gate behavior)
 
 CI workflow (`.github/workflows/ci.yml`):
-- `ci`: `fmt` (gofmt + goimports-reviser, diff check) + `cover-check` + `lint` + `build-all`
+- `ci`: `make ci COVER_MIN=80` (`fmt-check` + `cover-check` + `lint` + `build-all`)
 - `docker-build`: Docker build validation (web default + CLI variant)
-- `api-integration`: `make test-api-integration`
-- `e2e-web`: `make test-e2e-web` (push/schedule)
+- `api-integration`: `make ci-api-integration`
+- `e2e-web`: `make ci-e2e-web` (push/schedule)
 - `govulncheck`: dependency vulnerability scan
 - `fieldalignment`: struct field alignment check
 
+<a id="troubleshooting"></a>
+## Troubleshooting
+
+### GitHub token and permissions
+
+- Symptom: conversion fails with GitHub auth/permission errors.
+- Checks:
+  - Confirm `GITHUB_TOKEN` is set (or pass `--token`).
+  - Confirm the token can read the target repo/discussion.
+  - For fine-grained tokens, ensure repository access is explicitly granted.
+
+### Docker daemon unavailable
+
+- Symptom: `make docker-build` fails with daemon connection errors.
+- Checks:
+  - Start Docker Desktop or Docker daemon.
+  - Run `docker info` and confirm it returns successfully.
+  - If local Docker is unavailable, rely on CI `docker-build` job for validation.
+
+### Slow upstream or timeout issues on `/convert`
+
+- Symptom: web conversion fails on slow upstream fetch/summarization paths.
+- Checks:
+  - Increase `ISSUE2MD_WEB_WRITE_TIMEOUT` (for example `120s`, `180s`) based on your SLA.
+  - Verify upstream network reachability and API latency.
+  - Re-run with a known small public issue URL to isolate environment latency.
+
+### CI formatting gate fails (`fmt-check`)
+
+- Symptom: CI reports formatting diff and blocks merge.
+- Fix:
+  - Run `make fmt`.
+  - Commit formatting changes.
+  - Re-run `make ci COVER_MIN=80` locally before pushing.
+
+<a id="docker"></a>
 ## Docker
 
 These commands are defined by `Dockerfile` and `Makefile`:
@@ -227,6 +281,7 @@ docker run --rm -p 8080:8080 \
 
 `Dockerfile` defaults to `APP=issue2mdweb`. Use `--build-arg APP=issue2md` for CLI image.
 
+<a id="documentation-maintenance"></a>
 ## Documentation Maintenance
 
 Update this README when these repository changes happen:
@@ -241,6 +296,7 @@ Update this README when these repository changes happen:
 | API route changed | Web API Example |
 | Go version changed | Badges, Quick Start prerequisites |
 
+<a id="governance-files"></a>
 ## Governance Files
 
 - `LICENSE`: present (`MIT`) -> [LICENSE](LICENSE)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,22 @@
 
 将 GitHub `Issue` / `Pull Request` / `Discussion` URL 转换为 Markdown 的 Go 工具，提供 CLI 与 Web 两种入口。
 
+## 目录
+
+- [项目概览](#cn-overview)
+- [快速开始](#cn-quick-start)
+- [项目结构](#cn-project-structure)
+- [架构与数据流](#cn-architecture-and-flow)
+- [常用命令](#cn-common-commands)
+- [配置与环境变量](#cn-configuration-and-env)
+- [API 示例（Web）](#cn-web-api-example)
+- [测试与质量检查](#cn-testing-and-quality)
+- [故障排查（Troubleshooting）](#cn-troubleshooting)
+- [部署与运行（Docker）](#cn-docker)
+- [文档维护说明](#cn-documentation-maintenance)
+- [治理文件状态](#cn-governance-files)
+
+<a id="cn-overview"></a>
 ## 项目概览
 
 - 语言策略：中文说明 + 英文技术术语（命令、路径、环境变量名保持英文）。
@@ -13,6 +29,7 @@
 - Go 版本：`go 1.25.7`（见 `go.mod`）。
 - 模块路径：`github.com/johnqtcg/issue2md`。
 
+<a id="cn-quick-start"></a>
 ## 快速开始
 
 ### 前置条件
@@ -25,21 +42,20 @@
 
 ### 命令可验证性（Command Verifiability Gate）
 
-说明：这里的 “Verified” 指本次 agent 会话在 `2026-03-04` 的实际执行结果，不等同于你本机历史执行状态。
-
-本次会话已执行并通过：
+在本地执行质量/构建命令前，请先安装依赖工具并运行：
 
 ```bash
 make help
-make fmt
-make test
-make lint
-make cover-check COVER_MIN=80
+make ci COVER_MIN=80
 make build-cli
 make web
 make swagger-check
 ./bin/issue2md --stdout https://github.com/github/spec-kit/issues/75
 ```
+
+验证策略：
+- 以你本地实际执行结果为准。
+- CI（`.github/workflows/ci.yml`）会在 Linux runner 上执行并校验必需门禁。
 
 ### 本地构建
 
@@ -85,6 +101,7 @@ ISSUE2MD_WEB_ADDR=127.0.0.1:18080 ./bin/issue2mdweb
 ISSUE2MD_WEB_WRITE_TIMEOUT=90s ./bin/issue2mdweb
 ```
 
+<a id="cn-project-structure"></a>
 ## 项目结构
 
 ```text
@@ -108,6 +125,7 @@ ISSUE2MD_WEB_WRITE_TIMEOUT=90s ./bin/issue2mdweb
 └── Dockerfile
 ```
 
+<a id="cn-architecture-and-flow"></a>
 ## 架构与数据流
 
 CLI 路径：
@@ -122,25 +140,26 @@ Web 路径：
 cmd/issue2mdweb -> internal/webapp -> internal/parser -> internal/github -> internal/converter -> HTTP响应
 ```
 
+<a id="cn-common-commands"></a>
 ## 常用命令
 
 命令来源优先级：`Makefile`（本仓库主命令入口）。
 
 | 命令 | 用途 | 状态 |
 |---|---|---|
-| `make help` | 查看所有目标 | Verified（local session） |
-| `make fmt` | 使用 `gofmt` + `goimports-reviser` 格式化 Go 代码 | Defined in Makefile + CI |
-| `make test` | 运行全部测试 | Verified（local session） |
-| `make lint` | 执行 `golangci-lint` | Verified（local session） |
-| `make cover-check COVER_MIN=80` | 覆盖率门禁 | Verified（local session） |
-| `make build-cli` | 构建 CLI | Verified（local session） |
-| `make web` | 构建 Web 二进制 | Verified（local session） |
-| `make swagger-check` | 重新生成并校验 OpenAPI 文档 | Verified（local session） |
-| `./bin/issue2md --stdout <github-url>` | 真实 GitHub URL 转换 | Verified（local session, requires `GITHUB_TOKEN`） |
-| `make test-api-integration` | 运行 API 集成测试（target 内设置 `ISSUE2MD_API_INTEGRATION=1`） | Defined in Makefile + CI |
-| `make test-e2e-web` | 运行 Web E2E（target 内设置 `ISSUE2MD_E2E=1`） | Defined in Makefile + CI |
-| `make docker-build` | 构建容器镜像 | Defined in Makefile + CI（Linux runner） |
+| `make help` | 查看所有目标 | Makefile |
+| `make fmt` | 使用 `gofmt` + `goimports-reviser` 格式化 Go 代码 | Makefile + CI 门禁 |
+| `make ci COVER_MIN=80` | 必需本地门禁（等价 CI：`fmt-check` + 覆盖率 + lint + build） | Makefile + CI |
+| `make test` | 运行全部测试 | Makefile |
+| `make build-cli` | 构建 CLI | Makefile |
+| `make web` | 构建 Web 二进制 | Makefile |
+| `make swagger-check` | 重新生成并校验 OpenAPI 文档 | Makefile |
+| `./bin/issue2md --stdout <github-url>` | 真实 GitHub URL 转换 | 需要 `GITHUB_TOKEN` |
+| `make ci-api-integration` | API 集成门禁等价命令 | Makefile + CI |
+| `make ci-e2e-web` | Web E2E 门禁等价命令 | Makefile + CI（`push`/`schedule`） |
+| `make docker-build` | 构建容器镜像 | Makefile + CI（Linux runner） |
 
+<a id="cn-configuration-and-env"></a>
 ## 配置与环境变量
 
 ### 运行时环境变量
@@ -173,6 +192,7 @@ cmd/issue2mdweb -> internal/webapp -> internal/parser -> internal/github -> inte
 <owner>-<repo>-<issue|pr|discussion>-<number>.md
 ```
 
+<a id="cn-web-api-example"></a>
 ## API 示例（Web）
 
 ### 路由
@@ -192,24 +212,60 @@ curl -sS -X POST http://127.0.0.1:8080/convert \
   --data-urlencode 'url=https://github.com/<owner>/<repo>/issues/1'
 ```
 
+<a id="cn-testing-and-quality"></a>
 ## 测试与质量检查
 
 ### 本地质量门禁
 
-- 单元/集成测试：`make test`
-- 代码格式化：`make fmt`
-- 静态检查：`make lint`
-- 覆盖率门禁：`make cover-check COVER_MIN=80`（当前环境结果：`81.5%`）
+- 必需门禁：`make ci COVER_MIN=80`
+- 附加检查：`make ci-api-integration`
+- 附加检查：`make ci-e2e-web`（可选，对齐 CI e2e job 触发语义）
 
 ### CI 工作流（`.github/workflows/ci.yml`）
 
-- `ci`: `fmt`（gofmt + goimports-reviser 并校验无 diff）+ `cover-check` + `lint` + `build-all`
+- `ci`: `make ci COVER_MIN=80`（`fmt-check` + `cover-check` + `lint` + `build-all`）
 - `docker-build`: Docker 镜像构建校验（默认 web 入口 + CLI 入口）
-- `api-integration`: `make test-api-integration`
-- `e2e-web`: `make test-e2e-web`（仅 `push` 或定时）
+- `api-integration`: `make ci-api-integration`
+- `e2e-web`: `make ci-e2e-web`（仅 `push` 或定时）
 - `govulncheck`: 依赖漏洞检查
 - `fieldalignment`: 结构体字段对齐检查
 
+<a id="cn-troubleshooting"></a>
+## 故障排查（Troubleshooting）
+
+### GitHub Token 与权限问题
+
+- 现象：转换请求返回 GitHub 鉴权/权限错误。
+- 排查：
+  - 确认已设置 `GITHUB_TOKEN`（或显式传入 `--token`）。
+  - 确认 token 对目标仓库/讨论有读取权限。
+  - 若是 fine-grained token，确认目标仓库已被明确授权。
+
+### Docker daemon 不可用
+
+- 现象：`make docker-build` 报 daemon 连接失败。
+- 排查：
+  - 确认 Docker Desktop 或 Docker daemon 已启动。
+  - 执行 `docker info`，确认命令可成功返回。
+  - 若本地无 Docker，可依赖 CI 的 `docker-build` job 做构建校验。
+
+### `/convert` 慢请求或超时问题
+
+- 现象：上游抓取/摘要较慢时，Web 转换失败。
+- 排查：
+  - 按 SLA 调整 `ISSUE2MD_WEB_WRITE_TIMEOUT`（例如 `120s`、`180s`）。
+  - 检查上游网络连通性与 API 延迟。
+  - 用已知的小型公开 issue URL 复测，以隔离环境延迟因素。
+
+### CI 格式化门禁失败（`fmt-check`）
+
+- 现象：CI 报格式化 diff，阻止合并。
+- 处理：
+  - 先执行 `make fmt`。
+  - 提交格式化改动。
+  - 推送前本地执行 `make ci COVER_MIN=80` 复核。
+
+<a id="cn-docker"></a>
 ## 部署与运行（Docker）
 
 以下命令来自 `Dockerfile` 与 `Makefile`。本地执行依赖 Docker daemon；CI 中已由 `docker-build` job 在 Linux runner 验证构建。
@@ -224,6 +280,7 @@ docker run --rm -p 8080:8080 \
 
 `Dockerfile` 默认 `APP=issue2mdweb`，可通过 `--build-arg APP=issue2md` 构建 CLI 入口。
 
+<a id="cn-documentation-maintenance"></a>
 ## 文档维护说明
 
 以下变更发生时，应同步更新本 README：
@@ -238,8 +295,9 @@ docker run --rm -p 8080:8080 \
 | API 路由变更 | API 示例（Web） |
 | Go 版本变更 | 徽章、快速开始 |
 
-维护建议：在提交前至少执行 `make test` 与 `make lint`，涉及覆盖率门禁时执行 `make cover-check COVER_MIN=80`。
+维护建议：在提交前至少执行 `make ci COVER_MIN=80`，必要时补充执行 `make ci-api-integration` 与 `make ci-e2e-web`。
 
+<a id="cn-governance-files"></a>
 ## 治理文件状态
 
 - `LICENSE`: present (`MIT`)


### PR DESCRIPTION
## Problem/Context
README documents had two reviewability issues:
- stale/time-bound statements (session date, fixed coverage value) that drift over time
- no clickable TOC in long bilingual docs, reducing navigation efficiency

## What Changed
- Added clickable TOC sections to both `README.md` and `README.zh-CN.md`
- Added stable section anchors for predictable intra-doc navigation
- Replaced time-bound verification wording with environment-driven verification policy
- Aligned quality guidance with current Makefile/CI gate commands (`make ci`, `ci-api-integration`, `ci-e2e-web`)
- Added `Troubleshooting` sections in both docs (token/permission, docker daemon, timeout tuning, CI fmt-check failure flow)

## Why This Approach
- Removes doc drift caused by static dates/metrics
- Keeps bilingual docs structurally aligned to reduce maintenance divergence
- Improves first-pass usability for contributors and reviewers via direct section jumps

## Risk and Rollback Plan
- Risk level: Low (documentation-only changes)
- Runtime/API behavior: No code path changes
- Rollback: Revert commit `e3a35a3` if wording or structure is not desired

## Test Evidence
- `make ci COVER_MIN=80` -> PASS
  - `go test ./...` PASS
  - coverage gate PASS (`81.80% >= 80.00%`)
  - `golangci-lint` PASS (`0 issues`)
  - `build-all` PASS

## Security Notes
- Secret filename scan on diff -> no hits
- Secret content scan on diff -> no hits
- No new runtime secret handling introduced

## Breaking Changes / Migration Notes
- None

## Reviewer Checklist
- [ ] TOC links jump to expected sections in both README files
- [ ] English/Chinese content is semantically aligned
- [ ] Quality command descriptions match current Makefile and CI workflow
- [ ] Troubleshooting entries are accurate and actionable
