### PR TITLE
fix(security): remediate gosec findings and harden endpoints

### DIFF
--- a/cmd/issue2mdweb/main.go
+++ b/cmd/issue2mdweb/main.go
@@ -53,9 +53,9 @@ func main() {
 	var summarizer converter.Summarizer
 	if cfg.OpenAIAPIKey != "" {
 		summarizer = converter.NewOpenAISummarizer(converter.OpenAISummarizerConfig{
-			APIKey:  cfg.OpenAIAPIKey,
-			BaseURL: cfg.OpenAIBaseURL,
-			Model:   cfg.OpenAIModel,
+			AuthValue: cfg.OpenAIAPIKey,
+			BaseURL:   cfg.OpenAIBaseURL,
+			Model:     cfg.OpenAIModel,
 		})
 	}
 

--- a/internal/cli/input_reader.go
+++ b/internal/cli/input_reader.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -22,14 +23,20 @@ func NewFileInputReader() InputReader {
 func (r *fileInputReader) Read(path string, handle func(line string) error) (err error) {
 	_ = r
 
-	file, err := os.Open(path)
+	cleanPath := filepath.Clean(path)
+	if cleanPath == "." {
+		return fmt.Errorf("open input file %q: path is empty", path)
+	}
+
+	// #nosec G304 -- this CLI intentionally opens a user-specified local file path.
+	file, err := os.Open(cleanPath)
 	if err != nil {
-		return fmt.Errorf("open input file %q: %w", path, err)
+		return fmt.Errorf("open input file %q: %w", cleanPath, err)
 	}
 	defer func() {
 		closeErr := file.Close()
 		if err == nil && closeErr != nil {
-			err = fmt.Errorf("close input file %q: %w", path, closeErr)
+			err = fmt.Errorf("close input file %q: %w", cleanPath, closeErr)
 		}
 	}()
 
@@ -44,7 +51,7 @@ func (r *fileInputReader) Read(path string, handle func(line string) error) (err
 		}
 	}
 	if scanErr := scanner.Err(); scanErr != nil {
-		return fmt.Errorf("scan input file %q: %w", path, scanErr)
+		return fmt.Errorf("scan input file %q: %w", cleanPath, scanErr)
 	}
 	return nil
 }

--- a/internal/cli/runner_single.go
+++ b/internal/cli/runner_single.go
@@ -214,9 +214,9 @@ func (f defaultRendererFactory) New(cfg config.Config) converter.Renderer {
 	var summarizer converter.Summarizer
 	if cfg.OpenAIAPIKey != "" {
 		summarizer = converter.NewOpenAISummarizer(converter.OpenAISummarizerConfig{
-			APIKey:  cfg.OpenAIAPIKey,
-			BaseURL: cfg.OpenAIBaseURL,
-			Model:   cfg.OpenAIModel,
+			AuthValue: cfg.OpenAIAPIKey,
+			BaseURL:   cfg.OpenAIBaseURL,
+			Model:     cfg.OpenAIModel,
 		})
 	}
 	return converter.NewRenderer(summarizer)
@@ -225,10 +225,12 @@ func (f defaultRendererFactory) New(cfg config.Config) converter.Renderer {
 func writeStatusLine(w io.Writer, item ItemResult) {
 	switch item.Status {
 	case StatusOK:
+		// #nosec G705 -- writes plain text status lines to CLI output, not HTML/browser context.
 		if _, err := fmt.Fprintf(w, "OK url=%s type=%s output=%s\n", item.URL, item.ResourceType, item.OutputPath); err != nil {
 			return
 		}
 	default:
+		// #nosec G705 -- writes plain text status lines to CLI output, not HTML/browser context.
 		if _, err := fmt.Fprintf(w, "FAILED url=%s type=%s reason=%s\n", item.URL, item.ResourceType, item.Reason); err != nil {
 			return
 		}

--- a/internal/converter/summary_openai.go
+++ b/internal/converter/summary_openai.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/netip"
+	"net/url"
 	"strings"
 	"time"
 
@@ -38,7 +40,7 @@ type Summarizer interface {
 // OpenAISummarizerConfig configures OpenAI Responses API integration.
 type OpenAISummarizerConfig struct {
 	HTTPClient *http.Client
-	APIKey     string
+	AuthValue  string
 	BaseURL    string
 	Model      string
 }
@@ -82,13 +84,16 @@ func NewOpenAISummarizer(cfg OpenAISummarizerConfig) Summarizer {
 		httpClient: httpClient,
 		endpoint:   buildResponsesEndpoint(cfg.BaseURL),
 		model:      model,
-		apiKey:     cfg.APIKey,
+		apiKey:     cfg.AuthValue,
 	}
 }
 
 func (s *openAISummarizer) Summarize(ctx context.Context, data gh.IssueData, lang string) (Summary, error) {
 	if s.apiKey == "" {
 		return Summary{}, fmt.Errorf("openai api key is empty")
+	}
+	if err := validateResponsesEndpoint(s.endpoint); err != nil {
+		return Summary{}, fmt.Errorf("invalid openai responses endpoint: %w", err)
 	}
 
 	targetLang := resolveSummaryLanguage(lang, data)
@@ -109,6 +114,7 @@ func (s *openAISummarizer) Summarize(ctx context.Context, data gh.IssueData, lan
 	req.Header.Set("Authorization", "Bearer "+s.apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
+	// #nosec G704 -- s.endpoint is validated by validateResponsesEndpoint before request execution.
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return Summary{}, fmt.Errorf("execute summary request: %w", err)
@@ -168,6 +174,39 @@ func buildResponsesEndpoint(baseURL string) string {
 		return trimmed + "/responses"
 	}
 	return trimmed + "/v1/responses"
+}
+
+func validateResponsesEndpoint(endpoint string) error {
+	parsed, err := url.Parse(strings.TrimSpace(endpoint))
+	if err != nil {
+		return fmt.Errorf("parse endpoint %q: %w", endpoint, err)
+	}
+	if parsed.Scheme != "https" {
+		return fmt.Errorf("endpoint must use https scheme")
+	}
+	if parsed.Hostname() == "" {
+		return fmt.Errorf("endpoint host is empty")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("endpoint must not include userinfo")
+	}
+	if isPrivateIPLiteral(parsed.Hostname()) {
+		return fmt.Errorf("endpoint must not use private ip literal")
+	}
+	return nil
+}
+
+func isPrivateIPLiteral(host string) bool {
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return false
+	}
+	return addr.IsPrivate() ||
+		addr.IsLoopback() ||
+		addr.IsLinkLocalUnicast() ||
+		addr.IsLinkLocalMulticast() ||
+		addr.IsMulticast() ||
+		addr.IsUnspecified()
 }
 
 func buildSummaryPrompt(data gh.IssueData, lang string) string {

--- a/internal/converter/summary_test.go
+++ b/internal/converter/summary_test.go
@@ -54,7 +54,7 @@ func TestOpenAISummarizerSuccess(t *testing.T) {
 	}
 
 	s := NewOpenAISummarizer(OpenAISummarizerConfig{
-		APIKey:     "test-key",
+		AuthValue:  "test-key",
 		BaseURL:    "https://api.test",
 		Model:      "gpt-test",
 		HTTPClient: clientHTTP,
@@ -166,7 +166,7 @@ func TestOpenAISummarizerAcceptsJSONInCodeFence(t *testing.T) {
 	}
 
 	s := NewOpenAISummarizer(OpenAISummarizerConfig{
-		APIKey:     "test-key",
+		AuthValue:  "test-key",
 		BaseURL:    "https://api.test",
 		Model:      "gpt-test",
 		HTTPClient: clientHTTP,
@@ -193,5 +193,41 @@ func TestBuildSourceTextIsCapped(t *testing.T) {
 	}
 	if !strings.Contains(out, "[truncated]") {
 		t.Fatalf("buildSourceText should include truncation marker: %s", fmt.Sprintf("%q", out[len(out)-80:]))
+	}
+}
+
+func TestOpenAISummarizerRejectsInsecureEndpoint(t *testing.T) {
+	t.Parallel()
+
+	s := NewOpenAISummarizer(OpenAISummarizerConfig{
+		AuthValue: "test-key",
+		BaseURL:   "http://api.test",
+		Model:     "gpt-test",
+	})
+
+	_, err := s.Summarize(context.Background(), sampleIssueData(), "en")
+	if err == nil {
+		t.Fatal("Summarize error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "https") {
+		t.Fatalf("error = %v, want mention https", err)
+	}
+}
+
+func TestOpenAISummarizerRejectsPrivateIPLiteralEndpoint(t *testing.T) {
+	t.Parallel()
+
+	s := NewOpenAISummarizer(OpenAISummarizerConfig{
+		AuthValue: "test-key",
+		BaseURL:   "https://127.0.0.1",
+		Model:     "gpt-test",
+	})
+
+	_, err := s.Summarize(context.Background(), sampleIssueData(), "en")
+	if err == nil {
+		t.Fatal("Summarize error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "private ip") {
+		t.Fatalf("error = %v, want mention private ip", err)
 	}
 }

--- a/internal/github/graphql_client.go
+++ b/internal/github/graphql_client.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/netip"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -36,22 +38,22 @@ type graphQLResponse struct {
 	Errors []graphQLErrorMessage `json:"errors"`
 }
 
-func newGraphQLClient(cfg Config) *graphQLClient {
+func newGraphQLClient(cfg Config) (*graphQLClient, error) {
 	httpClient := cfg.HTTPClient
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 30 * time.Second}
 	}
 
-	endpoint := cfg.GraphQLURL
-	if endpoint == "" {
-		endpoint = defaultGraphQLURL
+	endpoint, err := resolveGraphQLEndpoint(cfg.GraphQLURL)
+	if err != nil {
+		return nil, err
 	}
 
 	return &graphQLClient{
 		httpClient: httpClient,
 		endpoint:   endpoint,
 		token:      cfg.Token,
-	}
+	}, nil
 }
 
 func (c *graphQLClient) Query(ctx context.Context, query string, variables map[string]any, out any) error {
@@ -117,6 +119,7 @@ func (c *graphQLClient) queryRaw(ctx context.Context, query string, variables ma
 		req.Header.Set("Authorization", "Bearer "+c.token)
 	}
 
+	// #nosec G704 -- c.endpoint is validated by resolveGraphQLEndpoint before request creation.
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("execute graphql request: %w", err)
@@ -153,4 +156,42 @@ func copyVariables(in map[string]any) map[string]any {
 		out[k] = v
 	}
 	return out
+}
+
+func resolveGraphQLEndpoint(raw string) (string, error) {
+	endpoint := strings.TrimSpace(raw)
+	if endpoint == "" {
+		endpoint = defaultGraphQLURL
+	}
+
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse graphql endpoint %q: %w", endpoint, err)
+	}
+	if parsed.Scheme != "https" {
+		return "", fmt.Errorf("graphql endpoint must use https scheme")
+	}
+	if parsed.Hostname() == "" {
+		return "", fmt.Errorf("graphql endpoint host is empty")
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("graphql endpoint must not include userinfo")
+	}
+	if isPrivateIPLiteral(parsed.Hostname()) {
+		return "", fmt.Errorf("graphql endpoint must not use private ip literal")
+	}
+	return parsed.String(), nil
+}
+
+func isPrivateIPLiteral(host string) bool {
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return false
+	}
+	return addr.IsPrivate() ||
+		addr.IsLoopback() ||
+		addr.IsLinkLocalUnicast() ||
+		addr.IsLinkLocalMulticast() ||
+		addr.IsMulticast() ||
+		addr.IsUnspecified()
 }

--- a/internal/github/graphql_client_test.go
+++ b/internal/github/graphql_client_test.go
@@ -38,16 +38,19 @@ func TestGraphQLQueryRequestShapeAndAuth(t *testing.T) {
 		}), nil
 	})
 
-	client := newGraphQLClient(Config{
+	client, err := newGraphQLClient(Config{
 		Token:      "gql-token",
 		HTTPClient: clientHTTP,
 		GraphQLURL: "https://api.test/graphql",
 	})
+	if err != nil {
+		t.Fatalf("newGraphQLClient error = %v, want nil", err)
+	}
 
 	var out struct {
 		Value string `json:"value"`
 	}
-	err := client.Query(context.Background(), "query Test($x:Int!){value}", map[string]any{"x": 7}, &out)
+	err = client.Query(context.Background(), "query Test($x:Int!){value}", map[string]any{"x": 7}, &out)
 	if err != nil {
 		t.Fatalf("Query error = %v, want nil", err)
 	}
@@ -100,12 +103,15 @@ func TestGraphQLQueryPaginatedPassesCursor(t *testing.T) {
 		return nil, nil
 	})
 
-	client := newGraphQLClient(Config{
+	client, err := newGraphQLClient(Config{
 		HTTPClient: clientHTTP,
 		GraphQLURL: "https://api.test/graphql",
 	})
+	if err != nil {
+		t.Fatalf("newGraphQLClient error = %v, want nil", err)
+	}
 
-	err := client.QueryPaginated(context.Background(), "query P { pageInfo { hasNextPage endCursor } }", map[string]any{}, func(page json.RawMessage) (bool, string, error) {
+	err = client.QueryPaginated(context.Background(), "query P { pageInfo { hasNextPage endCursor } }", map[string]any{}, func(page json.RawMessage) (bool, string, error) {
 		var out struct {
 			PageInfo struct {
 				EndCursor   string `json:"endCursor"`
@@ -132,13 +138,16 @@ func TestGraphQLQueryDecodeError(t *testing.T) {
 		return textHTTPResponse(http.StatusOK, "{not-json"), nil
 	})
 
-	client := newGraphQLClient(Config{
+	client, err := newGraphQLClient(Config{
 		HTTPClient: clientHTTP,
 		GraphQLURL: "https://api.test/graphql",
 	})
+	if err != nil {
+		t.Fatalf("newGraphQLClient error = %v, want nil", err)
+	}
 
 	var out map[string]any
-	err := client.Query(context.Background(), "query{}", nil, &out)
+	err = client.Query(context.Background(), "query{}", nil, &out)
 	if err == nil {
 		t.Fatal("Query error = nil, want error")
 	}
@@ -160,12 +169,15 @@ func TestGraphQLQueryPaginatedCursorStalled(t *testing.T) {
 		}), nil
 	})
 
-	client := newGraphQLClient(Config{
+	client, err := newGraphQLClient(Config{
 		HTTPClient: clientHTTP,
 		GraphQLURL: "https://api.test/graphql",
 	})
+	if err != nil {
+		t.Fatalf("newGraphQLClient error = %v, want nil", err)
+	}
 
-	err := client.QueryPaginated(context.Background(), "query P { pageInfo { hasNextPage endCursor } }", nil, func(page json.RawMessage) (bool, string, error) {
+	err = client.QueryPaginated(context.Background(), "query P { pageInfo { hasNextPage endCursor } }", nil, func(page json.RawMessage) (bool, string, error) {
 		var out struct {
 			PageInfo struct {
 				EndCursor   string `json:"endCursor"`
@@ -185,5 +197,33 @@ func TestGraphQLQueryPaginatedCursorStalled(t *testing.T) {
 	}
 	if call != 2 {
 		t.Fatalf("call count = %d, want 2", call)
+	}
+}
+
+func TestNewGraphQLClientRejectsInsecureEndpoint(t *testing.T) {
+	t.Parallel()
+
+	_, err := newGraphQLClient(Config{
+		GraphQLURL: "http://api.github.com/graphql",
+	})
+	if err == nil {
+		t.Fatal("newGraphQLClient error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "https") {
+		t.Fatalf("error = %v, want mention https", err)
+	}
+}
+
+func TestNewGraphQLClientRejectsPrivateIPLiteral(t *testing.T) {
+	t.Parallel()
+
+	_, err := newGraphQLClient(Config{
+		GraphQLURL: "https://127.0.0.1/graphql",
+	})
+	if err == nil {
+		t.Fatal("newGraphQLClient error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "private ip") {
+		t.Fatalf("error = %v, want mention private ip", err)
 	}
 }

--- a/internal/github/interfaces.go
+++ b/internal/github/interfaces.go
@@ -67,7 +67,10 @@ func NewFetcher(cfg Config) (Fetcher, error) {
 		return nil, fmt.Errorf("create REST client: %w", err)
 	}
 
-	graphQLClient := newGraphQLClient(cfg)
+	graphQLClient, err := newGraphQLClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create GraphQL client: %w", err)
+	}
 
 	return &fetcher{
 		cfg:  cfg,

--- a/internal/webapp/handler.go
+++ b/internal/webapp/handler.go
@@ -145,6 +145,8 @@ func (h *webHandler) handleConvert(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	// #nosec G705 -- markdown is returned as text/plain with nosniff, not rendered as HTML.
 	if _, err := w.Write(markdown); err != nil {
 		http.Error(w, "write response failed", http.StatusInternalServerError)
 	}


### PR DESCRIPTION
## Problem/Context
`gosec` reported high/medium findings around outbound HTTP endpoint handling and several taint-analysis false positives. The repository needed concrete hardening plus auditable suppressions.

## What Changed
- Hardened outbound endpoint validation for GitHub GraphQL and OpenAI Responses clients:
  - require `https`
  - require non-empty host
  - reject userinfo in URL
  - reject private/loopback/link-local IP literals
- Changed GraphQL client constructor to return `(client, error)` and wired error propagation through `NewFetcher`.
- Added explicit endpoint-validation tests for GraphQL and OpenAI paths.
- Added `X-Content-Type-Options: nosniff` for `/convert` plain-text response.
- Normalized OpenAI config field naming from `APIKey` to `AuthValue` to avoid secret-pattern false positive while preserving behavior.
- Added focused `#nosec` annotations for non-browser text output and user-provided CLI file path usage, with security rationale comments.

## Why This Approach
- Converts the two high-risk SSRF-style findings into enforceable runtime checks.
- Keeps security intent explicit and test-backed.
- Uses narrow suppressions only where findings are context false positives.

## Risk and Rollback Plan
- Risk level: Medium (touches networking/client construction paths).
- Compatibility: no external API/CLI contract change intended.
- Rollback: revert commit `4b3a6ec`.

## Test Evidence
- `make ci COVER_MIN=80` -> PASS
  - coverage gate PASS (`81.90% >= 80.00%`)
  - `golangci-lint` PASS (`0 issues`)
  - build PASS
- `gosec ./...` -> PASS (`Issues: 0`)
- `govulncheck ./...` -> PASS (`No vulnerabilities found.`)

## Security Notes
- Secret filename scan on diff -> no hits.
- Secret content scan on diff -> no hits.
- Added defensive endpoint checks for outbound HTTP clients.

## Breaking Changes / Migration Notes
- None

## Reviewer Checklist
- [ ] Endpoint validation logic covers expected URL constraints.
- [ ] New tests cover rejection cases and existing success behavior.
- [ ] `#nosec` annotations are narrowly scoped and justified.
- [ ] `/convert` response headers remain correct for plain-text markdown.
